### PR TITLE
Make sure sim filter spinner is visible when empty layout is showing

### DIFF
--- a/res/layout/conversation_list_screen.xml
+++ b/res/layout/conversation_list_screen.xml
@@ -46,17 +46,17 @@
             android:background="@android:color/white"
             android:fadingEdgeLength="16dip" />
 
+        <TextView android:id="@+id/empty"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:background="@android:color/white"
+            android:text="@string/loading_conversations"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
     </LinearLayout>
 
-    <TextView android:id="@+id/empty"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:background="@android:color/white"
-        android:text="@string/loading_conversations"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+    <include layout="@layout/banner_sms_promo" />
 
-     <include layout="@layout/banner_sms_promo" />
-
-     <include layout="@layout/floating_action_button" />
+    <include layout="@layout/floating_action_button" />
 </RelativeLayout>


### PR DESCRIPTION
Change-Id: Iefe3d32b2dc9066c81e36fc058b4c961bfc6a9d6
(cherry picked from commit f7ee417fafde5bbfc5c79bad5a5ae15bd9656793)