### PR TITLE
Apply zoom scale to all items in ListView.

### DIFF
--- a/src/com/android/mms/ui/ComposeMessageActivity.java
+++ b/src/com/android/mms/ui/ComposeMessageActivity.java
@@ -2028,10 +2028,12 @@ public class ComposeMessageActivity extends Activity
     public void onZoomWithScale(float scale) {
         if (mMsgListView != null) {
             mMsgListView.handleZoomWithScale(scale);
+            int fontSize = mMsgListView.getZoomFontSize();
+            if (mTextEditor != null) {
+                mTextEditor.setTextSize(fontSize);
+            }
         }
-        if (mTextEditor != null) {
-            ZoomMessageListItem.zoomViewByScale(this, mTextEditor, scale);
-        }
+
     }
 
     private void showSubjectEditor(boolean show) {

--- a/src/com/android/mms/ui/MessageListAdapter.java
+++ b/src/com/android/mms/ui/MessageListAdapter.java
@@ -46,6 +46,8 @@ import android.widget.ListView;
 
 import com.android.mms.LogTag;
 import com.android.mms.R;
+import com.android.mms.ui.zoom.ZoomMessageListItem;
+import com.android.mms.ui.zoom.ZoomMessageListView;
 import com.google.android.mms.MmsException;
 
 /**
@@ -256,6 +258,8 @@ public class MessageListAdapter extends CursorAdapter {
 
                 mBodyCache.put(position, msgItem.mBody);
             }
+
+            handleZoomForItem(view);
         }
     }
 
@@ -330,6 +334,7 @@ public class MessageListAdapter extends CursorAdapter {
             // We've got an mms item, pre-inflate the mms portion of the view
             view.findViewById(R.id.mms_layout_view_stub).setVisibility(View.VISIBLE);
         }
+        handleZoomForItem(view);
         return view;
     }
 
@@ -344,6 +349,19 @@ public class MessageListAdapter extends CursorAdapter {
             }
         }
         return item;
+    }
+
+    /**
+     * Handle zoom for zoomable list items.
+     * @param view A view that should be zoomed, if it is a ZoomMessageListItem
+     */
+    private void handleZoomForItem(View view) {
+        if (mListView != null
+                && mListView instanceof ZoomMessageListView
+                && view instanceof ZoomMessageListItem) {
+            int zoomFontSize = ((ZoomMessageListView) mListView).getZoomFontSize();
+            ((ZoomMessageListItem) view).setZoomFontSize(zoomFontSize);
+        }
     }
 
     private boolean isCursorValid(Cursor cursor) {

--- a/src/com/android/mms/ui/MessageListItem.java
+++ b/src/com/android/mms/ui/MessageListItem.java
@@ -57,6 +57,7 @@ import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.method.HideReturnsTransformationMethod;
+import android.text.style.AbsoluteSizeSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.LineHeightSpan;
 import android.text.style.StyleSpan;
@@ -64,6 +65,7 @@ import android.text.style.TextAppearanceSpan;
 import android.text.style.URLSpan;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
@@ -279,6 +281,7 @@ public class MessageListItem extends ZoomMessageListItem implements
                                             mMessageItem.mHighlight,
                                             mMessageItem.mTextContentType));
 
+        mBodyTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mZoomFontSize);
         mDateView.setText(buildTimestampLine(msgSizeText + " " + mMessageItem.mTimestamp));
 
         updateSimIndicatorView(mMessageItem.mPhoneId);
@@ -563,7 +566,7 @@ public class MessageListItem extends ZoomMessageListItem implements
             }
         }
         drawRightStatusIndicator(mMessageItem);
-
+        mBodyTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mZoomFontSize);
         requestLayout();
     }
 

--- a/src/com/android/mms/ui/zoom/ZoomMessageListItem.java
+++ b/src/com/android/mms/ui/zoom/ZoomMessageListItem.java
@@ -17,6 +17,9 @@
 package com.android.mms.ui.zoom;
 
 import android.content.Context;
+import android.os.Handler;
+import android.text.SpannableStringBuilder;
+import android.text.style.AbsoluteSizeSpan;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.widget.LinearLayout;
@@ -39,12 +42,10 @@ public class ZoomMessageListItem extends LinearLayout {
     // Log tag
     private static final String TAG = ZoomMessageListItem.class.getSimpleName();
 
-    // "Zooming" constants
-    private static final int MIN_FONT_SIZE = 14;  //sp
-    private static final int MAX_FONT_SIZE = 72;  //sp
-
     // Members
     private final List<TextView> mZoomableTextViewList = new ArrayList<TextView>();
+
+    protected int mZoomFontSize = ZoomMessageListView.MIN_FONT_SIZE;
 
     /**
      * Constructor
@@ -77,66 +78,34 @@ public class ZoomMessageListItem extends LinearLayout {
         if (!mZoomableTextViewList.contains(textView)) {
             mZoomableTextViewList.add(textView);
         }
+
+
     }
 
     /**
-     * Accept the scale to use and handle "zooming" the text to the given scale
+     * Accept the font size to use and handle "zooming" the text to the given scale
      *
-     * @param scale {@link java.lang.Float}
+     * @param fontSize {@link java.lang.Integer}
      */
-    public void handleZoomWithScale(final float scale) {
-        getHandler().post(new Runnable() {
-            @Override
-            public void run() {
-                for (TextView textView : mZoomableTextViewList) {
-                    zoomViewByScale(getContext(), textView, scale);
+    public void setZoomFontSize(final int fontSize) {
+        mZoomFontSize = fontSize;
+        handleZoomFontSize();
+    }
+
+    /**
+     * "Zoom" the font size to mZoomFontSize, if a handler is attached to this view.
+     */
+    private void handleZoomFontSize() {
+        Handler handler = getHandler();
+        if (handler != null) {
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    for (TextView textView : mZoomableTextViewList) {
+                        textView.setTextSize(mZoomFontSize);
+                    }
                 }
-            }
-        });
-    }
-
-    /**
-     * This will "zoom" the text by changing the font size based ont he given scale for the given
-     * view
-     *
-     * @param context {@link android.content.Context}
-     * @param view    {@link android.widget.TextView}
-     * @param scale   {@link java.lang.Float}
-     */
-    public static void zoomViewByScale(Context context, TextView view, float scale) {
-        if (view == null) {
-            Log.w(TAG, "'view' is null!");
-            return;
+            });
         }
-        // getTextSize() returns absolute pixels
-        // convert to scaled for proper math flow
-        float currentTextSize = pixelsToSp(context, view.getTextSize());
-        // Calculate based on the scale (1.1 and 0.95 in this case)
-        float calculatedSize = currentTextSize * scale;
-        // Limit max and min
-        if (calculatedSize > MAX_FONT_SIZE) {
-            currentTextSize = MAX_FONT_SIZE;
-        } else if (calculatedSize < MIN_FONT_SIZE) {
-            currentTextSize = MIN_FONT_SIZE;
-        } else {
-            // Specify the calculated if we are within the reasonable bounds
-            currentTextSize = calculatedSize;
-        }
-        // Cast to int in order to normalize it
-        // setTextSize takes a Scaled Pixel value
-        view.setTextSize((int) currentTextSize);
-
-    }
-
-    /**
-     * Convert absolute pixels to scaled pixels based on density
-     *
-     * @param px {@link java.lang.Float}
-     *
-     * @return {@link java.lang.Float}
-     */
-    private static float pixelsToSp(Context context, float px) {
-        float scaledDensity = context.getResources().getDisplayMetrics().scaledDensity;
-        return px / scaledDensity;
     }
 }

--- a/src/com/android/mms/ui/zoom/ZoomMessageListView.java
+++ b/src/com/android/mms/ui/zoom/ZoomMessageListView.java
@@ -32,6 +32,10 @@ import com.android.mms.ui.MessageListItem;
  */
 public class ZoomMessageListView extends ListView {
 
+    public static final int MIN_FONT_SIZE = 14;  //sp
+    public static final int MAX_FONT_SIZE = 72;  //sp.0f;
+    private int mCurrentFontSize = MIN_FONT_SIZE;
+
     public ZoomMessageListView(Context context) {
         super(context);
     }
@@ -56,13 +60,45 @@ public class ZoomMessageListView extends ListView {
      * @param scale {@link java.lang.Float}
      */
     public void handleZoomWithScale(float scale) {
+        updateZoomViewByScale(scale);
         int viewCount = getChildCount();
         for (int i = 0; i < viewCount; i++) {
             View view = getChildAt(i);
             if (view instanceof ZoomMessageListItem) {
-                ((ZoomMessageListItem) view).handleZoomWithScale(scale);
+                ((ZoomMessageListItem) view).setZoomFontSize(mCurrentFontSize);
             }
         }
     }
 
+    /**
+     * This will "zoom" the text by changing the font size based ont he given scale for the given
+     * view
+     *
+     * @param scale   {@link java.lang.Float}
+     */
+    public void updateZoomViewByScale(float scale) {
+        // getTextSize() returns absolute pixels
+        // convert to scaled for proper math flow
+        //float currentTextSize = pixelsToSp(context, view.getTextSize());
+
+        // Calculate based on the scale (1.1 and 0.95 in this case)
+        float calculatedSize = mCurrentFontSize * scale;
+        // Limit max and min
+        if (calculatedSize > MAX_FONT_SIZE) {
+            mCurrentFontSize = MAX_FONT_SIZE;
+        } else if (calculatedSize < MIN_FONT_SIZE) {
+            mCurrentFontSize = MIN_FONT_SIZE;
+        } else {
+            // Specify the calculated if we are within the reasonable bounds
+            mCurrentFontSize = (int)calculatedSize;
+        }
+    }
+
+    /**
+     * Get the currently set font size for the current zoom level.
+     * @return The currently set font size.
+     */
+    public int getZoomFontSize() {
+        return mCurrentFontSize;
+    }
 }


### PR DESCRIPTION
- The zoom scale only affected items in the list that were currently
  visible. If you scroll, it does not stay applied.
- Implement the adapter such that it will apply the zoom scale to every
  item as you scroll.
- Store the zoom level in each item and format the text that will be
  displayed, such that as soon as the TextView enters the visible
  portion of the ListView, it will be rendered at the right size.

Change-Id: I116f3bf5f6bdb1c2b4cd6e4df5c5ef78fc222a96