### PR TITLE
MMS: Fix Unicode Strip Preference summary

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -278,7 +278,8 @@
             android:title="@string/pref_title_unicode_stripping"
             android:summary="%s"
             android:entries="@array/pref_unicode_stripping_entries"
-            android:entryValues="@array/pref_unicode_stripping_values" />
+            android:entryValues="@array/pref_unicode_stripping_values"
+            android:defaultValue="0" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
If the value wasn't changed yet, the summary is shown as '%s' due to the lack of a defined default value. Fixit.

Change-Id: Id6c6b790a11248d1461a28ed85f196d509046e87