### PR TITLE
Mms: give sender text more space to accommodate Chinese characters

### DIFF
--- a/res/layout/conversation_list_item.xml
+++ b/res/layout/conversation_list_item.xml
@@ -43,15 +43,15 @@
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
             android:layout_alignParentEnd="true"
+            android:layout_alignBaseline="@+id/from"
             android:textAppearance="@android:style/TextAppearance.Material.Caption"
             android:singleLine="true" />
 
-        <TextView android:id="@+id/from"
+        <TextView android:id="@id/from"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
             android:layout_toStartOf="@id/date"
-            android:layout_alignBaseline="@id/date"
             android:layout_alignWithParentIfMissing="true"
             android:textAppearance="@android:style/TextAppearance.Material.Subhead"
             android:singleLine="true"


### PR DESCRIPTION
Make "date" alignBaseline with "from"
 since "date" uses smaller text size (12sp) than "from".

Change-Id: Ic2a380961211a872ec81316a04599422d50e2195