### PR TITLE
MSIM fixes.

### DIFF
--- a/res/layout/message_list_item_recv.xml
+++ b/res/layout/message_list_item_recv.xml
@@ -85,15 +85,24 @@
                         android:id="@+id/sim_indicator_icon"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingEnd="3dip"
+                        android:paddingEnd="4dip"
                         android:tint="?android:attr/textColorSecondary"
                         android:visibility="gone"
                         android:layout_gravity="center_vertical"/>
 
+                    <TextView
+                        android:id="@+id/sim_name"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:paddingEnd="16dip"
+                        android:visibility="gone"
+                        android:textAppearance="@android:style/TextAppearance.Material.Caption" />
+
                     <TextView android:id="@+id/date_view"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingEnd="3dip"
+                        android:paddingEnd="4dip"
                         android:textAppearance="@android:style/TextAppearance.Material.Caption" />
 
                     <ImageView
@@ -101,7 +110,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:src="@drawable/ic_lock_message_sms"
-                        android:paddingEnd="3dip"
+                        android:paddingEnd="4dip"
                         android:visibility="gone" />
 
                     <ImageView
@@ -109,7 +118,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:src="@drawable/ic_sms_mms_delivered"
-                        android:paddingEnd="3dip"
+                        android:paddingEnd="4dip"
                         android:visibility="gone" />
 
                     <ImageView

--- a/res/layout/message_list_item_send.xml
+++ b/res/layout/message_list_item_send.xml
@@ -85,14 +85,14 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:src="@drawable/ic_lock_message_sms"
-                        android:paddingEnd="3dip"
+                        android:paddingEnd="4dip"
                         android:visibility="gone" />
 
                     <ImageView
                         android:id="@+id/delivered_indicator"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingEnd="3dip"
+                        android:paddingEnd="4dip"
                         android:src="@drawable/ic_sms_mms_delivered"
                         android:visibility="gone" />
 
@@ -100,7 +100,7 @@
                         android:id="@+id/details_indicator"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingEnd="3dip"
+                        android:paddingEnd="4dip"
                         android:src="@drawable/ic_sms_mms_details"
                         android:visibility="gone" />
 
@@ -108,10 +108,17 @@
                         android:id="@+id/sim_indicator_icon"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingEnd="3dip"
+                        android:paddingEnd="4dip"
                         android:tint="?android:attr/textColorSecondary"
                         android:visibility="gone"
                         android:layout_gravity="center_vertical" />
+
+                    <TextView android:id="@+id/sim_name"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:paddingEnd="16dip"
+                        android:textAppearance="@android:style/TextAppearance.Material.Caption" />
 
                     <TextView android:id="@+id/date_view"
                         android:layout_width="wrap_content"


### PR DESCRIPTION
Don't assume the SIM name is the most important piece of information and
thus don't intermix SIM name display and content: For the notification,
show the SIM name as sub text at the bottom of the notification; and in
the message list, show it next to the SIM number indicator.

Change-Id: I0469a9f3559abb125458717f1e6661426f59fb2f